### PR TITLE
Add skeleton React/Express TypeScript SaaS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# dependencies
+client/node_modules
+server/node_modules
+
+# builds
+client/dist
+server/dist

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Invoice SaaS
+
+This project provides a basic full stack application for managing clients, quotes and invoices. It contains:
+
+- **server** – an Express API written in TypeScript that connects to MySQL.
+- **client** – a React front end created with Vite and TypeScript.
+
+## Getting started
+
+Each part of the stack maintains its own dependencies. Install them using npm:
+
+```bash
+cd server && npm install
+cd ../client && npm install
+```
+
+To build the TypeScript sources:
+
+```bash
+npm run build
+```
+
+The client is configured to proxy API requests to the server on port 3001.
+
+## Running the app
+
+Start the server and client in separate terminals:
+
+```bash
+cd server && npm run build && npm start
+```
+
+```bash
+cd client && npm run dev
+```
+
+This skeleton can be extended to handle full CRUD operations for clients, quotes and invoices.

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Invoice SaaS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "invoice-saas-client",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^3.0.0",
+    "typescript": "^5.0.4"
+  }
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+interface Client {
+  id: number;
+  name: string;
+}
+
+function App() {
+  const [clients, setClients] = useState<Client[]>([]);
+
+  useEffect(() => {
+    fetch('/api/clients')
+      .then(res => res.json())
+      .then(setClients)
+      .catch(console.error);
+  }, []);
+
+  return (
+    <div>
+      <h1>Clients</h1>
+      <ul>
+        {clients.map(c => (
+          <li key={c.id}>{c.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default App;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
+});

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "invoice-saas-server",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mysql2": "^3.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "typescript": "^5.0.4",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,0 +1,8 @@
+import mysql from 'mysql2/promise';
+
+export const pool = mysql.createPool({
+  host: process.env.DB_HOST || 'localhost',
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASS || '',
+  database: process.env.DB_NAME || 'saasdb',
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,16 @@
+import express from 'express';
+import clients from './routes/clients';
+import invoices from './routes/invoices';
+import quotes from './routes/quotes';
+
+const app = express();
+app.use(express.json());
+
+app.use('/api/clients', clients);
+app.use('/api/invoices', invoices);
+app.use('/api/quotes', quotes);
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/server/src/routes/clients.ts
+++ b/server/src/routes/clients.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { pool } from '../db';
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+  const [rows] = await pool.query('SELECT * FROM clients');
+  res.json(rows);
+});
+
+export default router;

--- a/server/src/routes/invoices.ts
+++ b/server/src/routes/invoices.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { pool } from '../db';
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+  const [rows] = await pool.query('SELECT * FROM invoices');
+  res.json(rows);
+});
+
+export default router;

--- a/server/src/routes/quotes.ts
+++ b/server/src/routes/quotes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { pool } from '../db';
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+  const [rows] = await pool.query('SELECT * FROM quotes');
+  res.json(rows);
+});
+
+export default router;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- create React client with Vite and TypeScript
- create Express server in TypeScript with basic routes
- document setup in README

## Testing
- `npm run build` in `server` *(fails: cannot find modules)*
- `npm run build` in `client` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc5e24af8832189bd46fe4a8abcb6